### PR TITLE
Remove runner image cleanup steps

### DIFF
--- a/.github/workflows/crc-action.yml
+++ b/.github/workflows/crc-action.yml
@@ -13,6 +13,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Remove unwanted stuff to free up disk image
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+  
+          sudo docker image prune --all --force
+
+          sudo swapoff -a
+          sudo rm -f /mnt/swapfile
+
       - name: Check out code
         uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ The CRC GitHub Action is a custom GitHub Action designed to integrate CRC into y
 This action facilitates the setup, start, and management of CRC instances directly within your GitHub
 Actions pipelines, enabling seamless testing and development of your workload on OpenShift/MicroShift.
 
-> [!NOTE]
-> You are advised to maximize available diskspace using a third-party action.
-
 
 ## Features
 
@@ -26,6 +23,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Remove unwanted stuff
+        run: |
+          # According to your needs
+          #sudo rm -rf /usr/share/dotnet
+          #sudo rm -rf /usr/local/lib/android
+
       - name: Set up CRC
         uses: crc-org/crc-github-action@v1
         with:
@@ -37,6 +40,10 @@ jobs:
 
       # Additional steps for your workflow
 ```
+
+> [!NOTE]
+> You are advised to maximize available diskspace using a third-party action.
+
 
 ### Inputs
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ The CRC GitHub Action is a custom GitHub Action designed to integrate CRC into y
 This action facilitates the setup, start, and management of CRC instances directly within your GitHub
 Actions pipelines, enabling seamless testing and development of your workload on OpenShift/MicroShift.
 
+> [!NOTE]
+> You are advised to maximize available diskspace using a third-party action.
+
+
 ## Features
 
 - **Automated CRC Setup**: Installs and configures CRC on the runner.

--- a/action.yml
+++ b/action.yml
@@ -81,20 +81,6 @@ runs:
         sudo apt install -y qemu-kvm libvirt-daemon libvirt-daemon-system virtiofsd
         sudo usermod -a -G libvirt $USER
 
-    - name: Remove unwanted stuff to free up disk image
-      shell: bash
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/ghc
-        sudo rm -rf "/usr/local/share/boost"
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
- 
-        sudo docker image prune --all --force
- 
-        sudo swapoff -a
-        sudo rm -f /mnt/swapfile
-
     - name: Set the crc config
       shell: bash
       env:


### PR DESCRIPTION
Fixes #15 


The action to remove things in the runner machine would be a choice of the workflow owner.

Imagine that your action is run, but all of a sudden you can't compile a dotnet-based service anymore? There are plenty of actions out there; I maintain my one, as this way I can control this for ALL my workflows: https://github.com/gbraad-actions/remove-unwanted.

If resources are a need for the action, this PR adds a mention in the README:

> [!NOTE]
> You are advised to maximize available diskspace using a third-party action

The argument could be to at least allow this to be toggled, but I would still believe it is not following separation of concerns. Refer people to use a public action to accomplish the same if this is so essential. Otherwise, people can run their own runners or pay for an Enterprise plan.

---

#### Update

According to the issue: https://github.com/actions/runner-images/issues/8166 this is a 'moving target'. Also, something we do not want to maintain.

This failed in commit: https://github.com/crc-org/crc-github-action/pull/16/commits/7815a2b7e21150430968a2a0cbc25793312a1d06, with the runner output: https://github.com/crc-org/crc-github-action/actions/runs/13647928128/job/38150100244

```
System.IO.IOException: No space left on device : '/home/runner/runners/2.322.0/_diag/Worker_20250304-065012-utc.log' 
```

Therefore, instead moved this removal to the test workflow and removed the specific recommendation.