### PR TITLE
change install else condition to arm64

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
         if [ ${{ runner.arch }} = "X64" ]; then
           CRC_ARCH="amd64"
         else
-          CRC_ARCH="amd64"
+          CRC_ARCH="arm64"
         fi
         URL="https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/crc-linux-${CRC_ARCH}.tar.xz"
         mkdir -p installer


### PR DESCRIPTION
This is now amd64 in both if/else cases, seems like a typo.

## Summary by Sourcery

Bug Fixes:
- Correct default CRC_ARCH assignment to 'arm64' for non-X64 runners in action.yml.